### PR TITLE
include_img and mean_abs_pixel_diff parameters for RandSpatialCropSlices

### DIFF
--- a/ARGUS/ARGUS_Transforms.py
+++ b/ARGUS/ARGUS_Transforms.py
@@ -52,6 +52,8 @@ class ARGUS_RandSpatialCropSlices(RandomizableTransform, Transform):
         require_labeled: bool = False,
         reduce_to_statistics: bool = False,
         extended: bool = False,
+        include_img: bool = False,
+        mean_abs_pixel_diff: bool = False
     ) -> None:
         RandomizableTransform.__init__(self, 1.0)
         self.num_slices = num_slices
@@ -61,6 +63,8 @@ class ARGUS_RandSpatialCropSlices(RandomizableTransform, Transform):
         self.require_labeled = require_labeled
         self.reduce_to_statistics = reduce_to_statistics
         self.extended = extended
+        self.include_img = include_img
+        self.mean_abs_pixel_diff = mean_abs_pixel_diff
         self._roi_start: Optional[Sequence[int]] = None
         self._roi_center_slice: int = -1
         self._roi_end: Optional[Sequence[int]] = None
@@ -162,6 +166,15 @@ class ARGUS_RandSpatialCropSlices(RandomizableTransform, Transform):
                 img = np.stack([outmean, outstd, outstdMin, outstdMax])
             else:
                 img = np.stack([outmean, outstd])
+            if self.include_img:
+                outrandframe = arr[self.R.randint(0,self.num_slices - 1)]
+                outrandframe = outrandframe.reshape((1,outrandframe.shape[0],outrandframe.shape[1]))
+                img = np.concatenate([outrandframe,img])
+            if self.mean_abs_pixel_diff:
+                outframediff = np.absolute(np.diff(arr,axis=self.axis))
+                outmeandiff = np.mean(outframediff,axis=self.axis)
+                outmeandiff = outmeandiff.reshape((1,outmeandiff.shape[0],outmeandiff.shape[1]))
+                img = np.concatenate([img,outmeandiff])
         return img
 
 
@@ -184,6 +197,8 @@ class ARGUS_RandSpatialCropSlicesd(RandomizableTransform, MapTransform, Invertib
         require_labeled: bool = False,
         reduce_to_statistics: Union[Sequence[bool], bool] = False,
         extended: bool = False,
+        include_img: bool = False,
+        mean_abs_pixel_diff: bool = False,
         allow_missing_keys: bool = False,
     ) -> None:
         """
@@ -197,6 +212,8 @@ class ARGUS_RandSpatialCropSlicesd(RandomizableTransform, MapTransform, Invertib
             roi_end: voxel coordinates for end of the crop ROI, if a coordinate is out of image,
                 use the end coordinate of image.
             roi_slices: list of slices for each of the spatial dimensions.
+            include_img: If enabled, a random raw frame from the chosen window of frames is concatenated with the Mean/Std statistics.
+            mean_abs_pixel_diff: If enabled, the mean absolute value of the difference between adjacent slices is concatenated with the Mean/Std statistics.
             allow_missing_keys: don't raise exception if key is missing.
         """
         #super().__init__(keys, allow_missing_keys)
@@ -209,6 +226,8 @@ class ARGUS_RandSpatialCropSlicesd(RandomizableTransform, MapTransform, Invertib
         self.require_labeled = require_labeled
         self.reduce_to_statistics = ensure_tuple_rep(reduce_to_statistics, len(self.keys))
         self.extended = extended
+        self.include_img = include_img
+        self.mean_abs_pixel_diff = mean_abs_pixel_diff
         self._roi_start: Optional[Sequence[int]] = None
         self._roi_center_slice: int = -1
         self._roi_end: Optional[Sequence[int]] = None
@@ -248,7 +267,7 @@ class ARGUS_RandSpatialCropSlicesd(RandomizableTransform, MapTransform, Invertib
         d = dict(data)
 
         for key, num_slices, reduce_to_statistics in self.key_iterator(d, self.num_slices, self.reduce_to_statistics):
-            cropper = ARGUS_RandSpatialCropSlices(num_slices=num_slices, axis=self.axis, center_slice=self._roi_center_slice, reduce_to_statistics=reduce_to_statistics, boundary=self.boundary, extended=self.extended)
+            cropper = ARGUS_RandSpatialCropSlices(num_slices=num_slices, axis=self.axis, center_slice=self._roi_center_slice, reduce_to_statistics=reduce_to_statistics, boundary=self.boundary, extended=self.extended,include_img=self.include_img,mean_abs_pixel_diff=self.mean_abs_pixel_diff)
             orig_size = d[key].shape
             d[key] = cropper(d[key])
             self.push_transform(


### PR DESCRIPTION
This commit contains modifications to the `ARGUS/ARGUS_Transforms.py` script to include 2 parameters for the RandSpatialCropSlices:
- `include_img` : If enabled, this includes a random raw frame from the chosen window of frames and concatenates it with the extended statistics.
- `mean_abs_pixel_diff` : If enabled, this includes the mean absolute value of the difference between adjacent slices (from the chosen window of frames) and concatenates it with the extended statistics.