### PR TITLE
BugFix: Removed reshape function from the include_random_slice code

### DIFF
--- a/ARGUS/ARGUS_Transforms.py
+++ b/ARGUS/ARGUS_Transforms.py
@@ -171,7 +171,6 @@ class ARGUS_RandSpatialCropSlices(RandomizableTransform, Transform):
                 r_max = r_min + 1
                 r_min,r_max,slices = make_slices(r_min,r_max,_start,_end)
                 outrandframe = arr[tuple(slices)]
-                outrandframe = outrandframe.reshape((1,outrandframe.shape[0],outrandframe.shape[1]))
                 img = np.concatenate([outrandframe,img])
             if self.include_mean_abs_diff:
                 outframediff = np.absolute(np.diff(arr,axis=self.axis))


### PR DESCRIPTION
@aylward 

It looks like the reshape function is not needed here. The output of make_slices brings in the vector with the correct dimensions.